### PR TITLE
Add factory business system

### DIFF
--- a/dotnet/resources/NeptuneEvo/Businesses/Factories/FactoryBusiness.cs
+++ b/dotnet/resources/NeptuneEvo/Businesses/Factories/FactoryBusiness.cs
@@ -1,10 +1,10 @@
-﻿using NeptuneEvo.Businesses;      // базовый класс
-using NeptuneEvo.Businesses.Models; // если есть
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace NeptuneEvo.Businesses.Factories
 {
+    // информация о задании на производство
     public class ProductionJob
     {
         public string ProductType { get; set; }
@@ -12,17 +12,75 @@ namespace NeptuneEvo.Businesses.Factories
         public DateTime EndTime { get; set; }
     }
 
-    public class FactoryBusiness : BaseBusiness  // или нужный вам родитель
+    // бизнес типа "Фабрика"
+    public class FactoryBusiness : Core.Business
     {
-        // здесь храним материалы, продукцию и очередь
+        // склады материалов и готовой продукции
         public Dictionary<string, int> MaterialsStorage { get; set; } = new();
         public Dictionary<string, int> ProductsStorage { get; set; } = new();
         public List<ProductionJob> ProductionQueue { get; set; } = new();
 
-        // вспомогательный метод, чтобы по ID получить фабрику
+        public FactoryBusiness(int id, string owner, int sellPrice, int type, System.Collections.Generic.List<Core.Product> products, GTANetworkAPI.Vector3 enterPoint, GTANetworkAPI.Vector3 unloadPoint, int bankID, int mafia, System.Collections.Generic.List<Core.Order> orders, double tax = 0.026)
+            : base(id, owner, sellPrice, type, products, enterPoint, unloadPoint, bankID, mafia, orders, tax)
+        {
+        }
+
         public static FactoryBusiness GetById(int id)
         {
-            return BusinessManager.Get(id) as FactoryBusiness;
+            return Core.BusinessManager.BizList.ContainsKey(id) ? Core.BusinessManager.BizList[id] as FactoryBusiness : null;
+        }
+
+        // запускаем производство, если хватает материалов
+        public bool TryStartProduction(string productType, int quantity, Dictionary<string, int> requiredMaterials, TimeSpan craftTime)
+        {
+            foreach (var req in requiredMaterials)
+            {
+                if (!MaterialsStorage.TryGetValue(req.Key, out var have) || have < req.Value * quantity)
+                    return false;
+            }
+
+            foreach (var req in requiredMaterials)
+                MaterialsStorage[req.Key] -= req.Value * quantity;
+
+            ProductionQueue.Add(new ProductionJob
+            {
+                ProductType = productType,
+                Quantity = quantity,
+                EndTime = DateTime.Now.Add(craftTime)
+            });
+
+            return true;
+        }
+
+        // переносим готовые продукты на склад
+        public void ProcessQueue()
+        {
+            var finished = ProductionQueue.FindAll(j => j.EndTime <= DateTime.Now);
+            foreach (var job in finished)
+            {
+                if (ProductsStorage.ContainsKey(job.ProductType))
+                    ProductsStorage[job.ProductType] += job.Quantity;
+                else
+                    ProductsStorage[job.ProductType] = job.Quantity;
+
+                ProductionQueue.Remove(job);
+            }
+        }
+
+        // сериализация для сохранения в БД
+        public string SerializeMaterials() => JsonConvert.SerializeObject(MaterialsStorage);
+        public string SerializeProducts() => JsonConvert.SerializeObject(ProductsStorage);
+        public string SerializeQueue() => JsonConvert.SerializeObject(ProductionQueue);
+
+        public void LoadData(string materials, string products, string queue)
+        {
+            if (!string.IsNullOrEmpty(materials))
+                MaterialsStorage = JsonConvert.DeserializeObject<Dictionary<string, int>>(materials);
+            if (!string.IsNullOrEmpty(products))
+                ProductsStorage = JsonConvert.DeserializeObject<Dictionary<string, int>>(products);
+            if (!string.IsNullOrEmpty(queue))
+                ProductionQueue = JsonConvert.DeserializeObject<List<ProductionJob>>(queue);
         }
     }
 }
+

--- a/dotnet/resources/NeptuneEvo/Core/Businesses.cs
+++ b/dotnet/resources/NeptuneEvo/Core/Businesses.cs
@@ -37,6 +37,7 @@ using NeptuneEvo.Table.Tasks.Player;
 using NeptuneEvo.VehicleData.LocalData;
 using NeptuneEvo.VehicleData.LocalData.Models;
 using NeptuneEvo.VehicleData.Models;
+using NeptuneEvo.Businesses.Factories;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace NeptuneEvo.Core
@@ -329,8 +330,34 @@ namespace NeptuneEvo.Core
                         List<Product> prodlist = JsonConvert.DeserializeObject<List<Product>>(Row["products"].ToString());
 
                         int id = Convert.ToInt32(Row["id"]);
-                        Business data = new Business(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), Convert.ToInt32(Row["type"]), prodlist, enterpoint, unloadpoint, bankmoney,
-                            Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                        int bizType = Convert.ToInt32(Row["type"]);
+                        Business data;
+                        if (bizType == 16)
+                        {
+                            using MySqlCommand cmdF = new MySqlCommand($"SELECT * FROM business_factories WHERE bizid={id}");
+                            using DataTable resF = MySQL.QueryRead(cmdF);
+
+                            var materials = "{}";
+                            var products = "{}";
+                            var queue = "[]";
+
+                            if (resF != null && resF.Rows.Count > 0)
+                            {
+                                materials = resF.Rows[0]["materials"].ToString();
+                                products = resF.Rows[0]["products"].ToString();
+                                queue = resF.Rows[0]["queue"].ToString();
+                            }
+
+                            var factory = new FactoryBusiness(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), bizType, prodlist, enterpoint, unloadpoint, bankmoney,
+                                Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                            factory.LoadData(materials, products, queue);
+                            data = factory;
+                        }
+                        else
+                        {
+                            data = new Business(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), bizType, prodlist, enterpoint, unloadpoint, bankmoney,
+                                Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                        }
                         lastBizID = id;
 
                         UpdateBusProd(data);
@@ -1025,6 +1052,10 @@ namespace NeptuneEvo.Core
                     case 14:
                         _ProductsList.Add(new Product(45000, 20, 0, "Корм для животных", false));
                         break;
+                    case 16:
+                        _ProductsList.Add(new Product(100, 0, 0, "Материалы", false));
+                        _ProductsList.Add(new Product(200, 0, 0, "Продукция", false));
+                        break;
                 }
                 return _ProductsList;
             }
@@ -1081,6 +1112,15 @@ namespace NeptuneEvo.Core
                         }
                         sessionData.TempBizID = biz.ID;
                         CarRoom.enterCarroom(player);
+                        return;
+                    case 16:
+                        if (biz.Owner != player.Name)
+                        {
+                            Notify.Send(player, NotifyType.Error, NotifyPosition.BottomCenter, "Только владелец фабрики может ей управлять", 3000);
+                            return;
+                        }
+                        sessionData.TempBizID = biz.ID;
+                        OpenFactoryMenu(player);
                         return;
                     case 6:
                         sessionData.TempBizID = biz.ID;
@@ -3091,9 +3131,27 @@ namespace NeptuneEvo.Core
                 cmd.Parameters.AddWithValue("@val10", taxes);
                 MySQL.Query(cmd);
 
+                if (type == 16)
+                {
+                    using MySqlCommand cmdF = new MySqlCommand
+                    {
+                        CommandText = "INSERT INTO business_factories (bizid, materials, products, queue) VALUES (@b0,@b1,@b2,@b3)"
+                    };
+                    cmdF.Parameters.AddWithValue("@b0", lastBizID);
+                    cmdF.Parameters.AddWithValue("@b1", JsonConvert.SerializeObject(new Dictionary<string, int>()));
+                    cmdF.Parameters.AddWithValue("@b2", JsonConvert.SerializeObject(new Dictionary<string, int>()));
+                    cmdF.Parameters.AddWithValue("@b3", JsonConvert.SerializeObject(new List<ProductionJob>()));
+                    MySQL.Query(cmdF);
+                }
+
                 NAPI.Task.Run(() =>
                 {
-                    Business biz = new Business(lastBizID, "Государство", govPrice, type, products_list, pos, new Vector3(), bankID, -1, new List<Order>(), taxes);
+                    Business biz;
+                    if (type == 16)
+                        biz = new FactoryBusiness(lastBizID, "Государство", govPrice, type, products_list, pos, new Vector3(), bankID, -1, new List<Order>(), taxes);
+                    else
+                        biz = new Business(lastBizID, "Государство", govPrice, type, products_list, pos, new Vector3(), bankID, -1, new List<Order>(), taxes);
+
                     biz.UpdateLabel();
                     BizList.TryAdd(lastBizID, biz);
 
@@ -3936,6 +3994,28 @@ namespace NeptuneEvo.Core
                 "SniperRifle",
             },*/
         };
+
+        public static void OpenFactoryMenu(ExtPlayer player)
+        {
+            try
+            {
+                var sessionData = player.GetSessionData();
+                if (sessionData == null) return;
+                if (!player.IsCharacterData()) return;
+                if (sessionData.TempBizID == -1 || !BizList.ContainsKey(sessionData.TempBizID)) return;
+                if (BizList[sessionData.TempBizID] is not FactoryBusiness factory) return;
+
+                factory.ProcessQueue();
+                Trigger.ClientEvent(player, "client.factory.open",
+                    JsonConvert.SerializeObject(factory.MaterialsStorage),
+                    JsonConvert.SerializeObject(factory.ProductsStorage),
+                    JsonConvert.SerializeObject(factory.ProductionQueue));
+            }
+            catch (Exception e)
+            {
+                Log.Write($"OpenFactoryMenu Exception: {e.ToString()}");
+            }
+        }
         #endregion
 
         public static void changeOwner(string oldName, string newName)
@@ -3956,6 +4036,32 @@ namespace NeptuneEvo.Core
             catch (Exception e)
             {
                 Log.Write($"changeOwner NAPI.Task Exception: {e.ToString()}");
+            }
+        }
+
+        [RemoteEvent("server.factory.createOrder")]
+        public static void Event_FactoryCreateOrder(ExtPlayer player, string product, int amount)
+        {
+            try
+            {
+                var sessionData = player.GetSessionData();
+                if (sessionData == null) return;
+                var characterData = player.GetCharacterData();
+                if (characterData == null) return;
+                if (sessionData.TempBizID == -1 || !BizList.ContainsKey(sessionData.TempBizID)) return;
+
+                if (BizList[sessionData.TempBizID] is not FactoryBusiness factory) return;
+                if (factory.Owner != player.Name) return;
+
+                var materials = new Dictionary<string, int> { { "Материалы", amount } };
+                if (factory.TryStartProduction(product, amount, materials, TimeSpan.FromMinutes(5 * amount)))
+                    Notify.Send(player, NotifyType.Success, NotifyPosition.BottomCenter, "Производство запущено", 3000);
+                else
+                    Notify.Send(player, NotifyType.Error, NotifyPosition.BottomCenter, "Недостаточно материалов", 3000);
+            }
+            catch (Exception e)
+            {
+                Log.Write($"Event_FactoryCreateOrder Exception: {e.ToString()}");
             }
         }
     }
@@ -4148,6 +4254,16 @@ namespace NeptuneEvo.Core
                     .Set(b => b.Mafia, Mafia)
                     .Set(b => b.Orders, JsonConvert.SerializeObject(Orders))
                     .UpdateAsync();
+
+                if (Type == 16 && this is FactoryBusiness factory)
+                {
+                    await db.BusinessFactories
+                        .Where(f => f.Bizid == ID)
+                        .Set(f => f.Materials, factory.SerializeMaterials())
+                        .Set(f => f.Products, factory.SerializeProducts())
+                        .Set(f => f.Queue, factory.SerializeQueue())
+                        .UpdateAsync();
+                }
                 
             }
             catch (Exception e)

--- a/dotnet/resources/NeptuneEvo/Database/Server/ServerStruct.generated.cs
+++ b/dotnet/resources/NeptuneEvo/Database/Server/ServerStruct.generated.cs
@@ -35,7 +35,8 @@ namespace Database
 		public ITable<Bindcfgs>                Bindcfg                { get { return this.GetTable<Bindcfgs>(); } }
 		public ITable<Bonuscodes>              Bonuscodes             { get { return this.GetTable<Bonuscodes>(); } }
 		public ITable<Businesses>              Businesses             { get { return this.GetTable<Businesses>(); } }
-		public ITable<Businesshistories>       Businesshistory        { get { return this.GetTable<Businesshistories>(); } }
+                public ITable<Businesshistories>       Businesshistory        { get { return this.GetTable<Businesshistories>(); } }
+                public ITable<BusinessFactories>       BusinessFactories      { get { return this.GetTable<BusinessFactories>(); } }
 		public ITable<Characters>              Characters             { get { return this.GetTable<Characters>(); } }
 		public ITable<Chatcfgs>                Chatcfg                { get { return this.GetTable<Chatcfgs>(); } }
 		public ITable<Compensations>           Compensation           { get { return this.GetTable<Compensations>(); } }
@@ -303,16 +304,25 @@ namespace Database
 		[Column("tax"),            Nullable         ] public double? Tax         { get; set; } // double
 	}
 
-	[Table("businesshistory")]
-	public partial class Businesshistories
-	{
-		[Column("autoid"), PrimaryKey, Identity] public int      Autoid { get; set; } // int(11)
-		[Column("bizid"),  NotNull             ] public int      Bizid  { get; set; } // int(11)
-		[Column("date"),   NotNull             ] public DateTime Date   { get; set; } // datetime
-		[Column("uuid"),   NotNull             ] public int      Uuid   { get; set; } // int(11)
-		[Column("item"),   NotNull             ] public string   Item   { get; set; } // varchar(50)
-		[Column("price"),  NotNull             ] public int      Price  { get; set; } // int(11)
-	}
+        [Table("businesshistory")]
+        public partial class Businesshistories
+        {
+                [Column("autoid"), PrimaryKey, Identity] public int      Autoid { get; set; } // int(11)
+                [Column("bizid"),  NotNull             ] public int      Bizid  { get; set; } // int(11)
+                [Column("date"),   NotNull             ] public DateTime Date   { get; set; } // datetime
+                [Column("uuid"),   NotNull             ] public int      Uuid   { get; set; } // int(11)
+                [Column("item"),   NotNull             ] public string   Item   { get; set; } // varchar(50)
+                [Column("price"),  NotNull             ] public int      Price  { get; set; } // int(11)
+        }
+
+        [Table("business_factories")]
+        public partial class BusinessFactories
+        {
+                [Column("bizid"),     PrimaryKey, NotNull] public int    Bizid     { get; set; } // int(11)
+                [Column("materials"), NotNull    ] public string Materials { get; set; } // text
+                [Column("products"),  NotNull    ] public string Products  { get; set; } // text
+                [Column("queue"),     NotNull    ] public string Queue     { get; set; } // text
+        }
 
 	[Table("characters")]
 	public partial class Characters
@@ -1132,11 +1142,17 @@ namespace Database
 				t.Id == Id);
 		}
 
-		public static Businesshistories Find(this ITable<Businesshistories> table, int Autoid)
-		{
-			return table.FirstOrDefault(t =>
-				t.Autoid == Autoid);
-		}
+                public static Businesshistories Find(this ITable<Businesshistories> table, int Autoid)
+                {
+                        return table.FirstOrDefault(t =>
+                                t.Autoid == Autoid);
+                }
+
+                public static BusinessFactories Find(this ITable<BusinessFactories> table, int Bizid)
+                {
+                        return table.FirstOrDefault(t =>
+                                t.Bizid == Bizid);
+                }
 
 		public static Characters Find(this ITable<Characters> table, int Uuid)
 		{


### PR DESCRIPTION
## Summary
- add FactoryBusiness implementation with production queue and storage
- enable factory creation and interaction in BusinessManager
- persist factory data in new `business_factories` table

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589ce2955c832fa63b7c0c8879f8ee