### PR TITLE
Add basic factory framework

### DIFF
--- a/dotnet/resources/NeptuneEvo/Businesses/Factories/FactoryBusiness.cs
+++ b/dotnet/resources/NeptuneEvo/Businesses/Factories/FactoryBusiness.cs
@@ -1,5 +1,5 @@
-﻿using NeptuneEvo.Businesses;      // базовый класс
-using NeptuneEvo.Businesses.Models; // если есть
+﻿using NeptuneEvo.Core;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -12,12 +12,77 @@ namespace NeptuneEvo.Businesses.Factories
         public DateTime EndTime { get; set; }
     }
 
-    public class FactoryBusiness : BaseBusiness  // или нужный вам родитель
+    public class FactoryBusiness : Business
     {
-        // здесь храним материалы, продукцию и очередь
+        // материалы, готовая продукция и очередь производства
         public Dictionary<string, int> MaterialsStorage { get; set; } = new();
         public Dictionary<string, int> ProductsStorage { get; set; } = new();
         public List<ProductionJob> ProductionQueue { get; set; } = new();
+
+        public FactoryBusiness(int id, string owner, int sellPrice, int type, List<Product> products,
+            Vector3 enterPoint, Vector3 unloadPoint, int bankID, int mafia, List<Order> orders, double tax = 0.026)
+            : base(id, owner, sellPrice, type, products, enterPoint, unloadPoint, bankID, mafia, orders, tax)
+        {
+        }
+
+        // запуск производства если есть материалы
+        public bool StartProduction(string product, int quantity, Dictionary<string, int> needMaterials, TimeSpan duration)
+        {
+            foreach (var mat in needMaterials)
+            {
+                if (!MaterialsStorage.ContainsKey(mat.Key) || MaterialsStorage[mat.Key] < mat.Value * quantity)
+                    return false;
+            }
+
+            foreach (var mat in needMaterials)
+                MaterialsStorage[mat.Key] -= mat.Value * quantity;
+
+            ProductionQueue.Add(new ProductionJob
+            {
+                ProductType = product,
+                Quantity = quantity,
+                EndTime = DateTime.Now.Add(duration)
+            });
+
+            return true;
+        }
+
+        // проверка очереди и добавление готовых изделий на склад
+        public void ProcessQueue()
+        {
+            var finished = new List<ProductionJob>();
+            foreach (var job in ProductionQueue)
+            {
+                if (DateTime.Now >= job.EndTime)
+                {
+                    if (!ProductsStorage.ContainsKey(job.ProductType))
+                        ProductsStorage[job.ProductType] = 0;
+
+                    ProductsStorage[job.ProductType] += job.Quantity;
+                    finished.Add(job);
+                }
+            }
+
+            foreach (var job in finished)
+                ProductionQueue.Remove(job);
+        }
+
+        // сериализация состояния для базы данных
+        public string SerializeMaterials() => JsonConvert.SerializeObject(MaterialsStorage);
+        public string SerializeProducts() => JsonConvert.SerializeObject(ProductsStorage);
+        public string SerializeQueue() => JsonConvert.SerializeObject(ProductionQueue);
+
+        public void LoadState(string materialsJson, string productsJson, string queueJson)
+        {
+            if (!string.IsNullOrEmpty(materialsJson))
+                MaterialsStorage = JsonConvert.DeserializeObject<Dictionary<string, int>>(materialsJson);
+
+            if (!string.IsNullOrEmpty(productsJson))
+                ProductsStorage = JsonConvert.DeserializeObject<Dictionary<string, int>>(productsJson);
+
+            if (!string.IsNullOrEmpty(queueJson))
+                ProductionQueue = JsonConvert.DeserializeObject<List<ProductionJob>>(queueJson);
+        }
 
         // вспомогательный метод, чтобы по ID получить фабрику
         public static FactoryBusiness GetById(int id)

--- a/dotnet/resources/NeptuneEvo/Core/Businesses.cs
+++ b/dotnet/resources/NeptuneEvo/Core/Businesses.cs
@@ -329,8 +329,23 @@ namespace NeptuneEvo.Core
                         List<Product> prodlist = JsonConvert.DeserializeObject<List<Product>>(Row["products"].ToString());
 
                         int id = Convert.ToInt32(Row["id"]);
-                        Business data = new Business(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), Convert.ToInt32(Row["type"]), prodlist, enterpoint, unloadpoint, bankmoney,
-                            Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                        Business data;
+                        int type = Convert.ToInt32(Row["type"]);
+                        if (type == 16)
+                        {
+                            using var dbMain = new ServerBD("MainDB");
+                            var factoryData = dbMain.FactoryDatas.FirstOrDefault(f => f.Id == id);
+                            var f = new Businesses.Factories.FactoryBusiness(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), type, prodlist, enterpoint, unloadpoint, bankmoney,
+                                Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                            if (factoryData != null)
+                                f.LoadState(factoryData.Materials, factoryData.Products, factoryData.Queue);
+                            data = f;
+                        }
+                        else
+                        {
+                            data = new Business(id, Row["owner"].ToString(), Convert.ToInt32(Row["sellprice"]), type, prodlist, enterpoint, unloadpoint, bankmoney,
+                                Convert.ToInt32(Row["mafia"]), JsonConvert.DeserializeObject<List<Order>>(Row["orders"].ToString()), Convert.ToDouble(Row["tax"]));
+                        }
                         lastBizID = id;
 
                         UpdateBusProd(data);
@@ -1025,6 +1040,9 @@ namespace NeptuneEvo.Core
                     case 14:
                         _ProductsList.Add(new Product(45000, 20, 0, "Корм для животных", false));
                         break;
+                    case 16:
+                        // фабрика не продает товары напрямую
+                        break;
                 }
                 return _ProductsList;
             }
@@ -1215,8 +1233,12 @@ namespace NeptuneEvo.Core
                         sessionData.TempBizID = biz.ID;
                         enterPetShop(player, biz.Products[0].Name);
                         return;
+                    case 16:
+                        sessionData.TempBizID = biz.ID;
+                        OpenFactoryMenu(player);
+                        return;
                     default:
-                        // Not supposed to end up here. 
+                        // Not supposed to end up here.
                         break;
                 }
             }
@@ -3734,6 +3756,22 @@ namespace NeptuneEvo.Core
             catch (Exception e)
             {
                 Log.Write($"OpenGunShopMenu Exception: {e.ToString()}");
+            }
+        }
+
+        public static void OpenFactoryMenu(ExtPlayer player)
+        {
+            try
+            {
+                if (!player.IsCharacterData()) return;
+                var sessionData = player.GetSessionData();
+                if (sessionData == null) return;
+                if (sessionData.TempBizID == -1 || !BizList.ContainsKey(sessionData.TempBizID)) return;
+                Notify.Send(player, NotifyType.Info, NotifyPosition.BottomCenter, "Фабрика открыта", 3000);
+            }
+            catch (Exception e)
+            {
+                Log.Write($"OpenFactoryMenu Exception: {e.ToString()}");
             }
         }
 

--- a/dotnet/resources/NeptuneEvo/Database/Models/Factory.cs
+++ b/dotnet/resources/NeptuneEvo/Database/Models/Factory.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Database;
+using LinqToDB;
+using NeptuneEvo.Businesses.Factories;
+using NeptuneEvo.Core;
+using Newtonsoft.Json;
+using Redage.SDK;
+
+namespace NeptuneEvo.Database.Models
+{
+    public class Factory
+    {
+        private static readonly nLog Log = new nLog("Database.Factory");
+
+        public static void Start()
+        {
+            var thread = new Thread(Worker);
+            thread.IsBackground = true;
+            thread.Name = "FactorySave";
+            thread.Start();
+        }
+        private static async void Worker()
+        {
+            while (true)
+            {
+                try
+                {
+                    var factories = BusinessManager.BizList
+                        .Where(b => b.Value.Type == 16)
+                        .Select(b => b.Value as FactoryBusiness)
+                        .Where(f => f != null)
+                        .ToList();
+
+                    if (factories.Count > 0)
+                    {
+                        await using var db = new ServerBD("MainDB");
+
+                        foreach (var factory in factories)
+                        {
+                            await db.FactoryDatas
+                                .Where(f => f.Id == factory.ID)
+                                .Set(f => f.Materials, factory.SerializeMaterials())
+                                .Set(f => f.Products, factory.SerializeProducts())
+                                .Set(f => f.Queue, factory.SerializeQueue())
+                                .UpdateAsync();
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debugs.Repository.Exception(e);
+                }
+                Thread.Sleep(1000 * 30);
+            }
+        }
+    }
+}

--- a/dotnet/resources/NeptuneEvo/Database/Models/Repository.cs
+++ b/dotnet/resources/NeptuneEvo/Database/Models/Repository.cs
@@ -1,4 +1,6 @@
-﻿namespace NeptuneEvo.Database.Models
+﻿using NeptuneEvo.Businesses.Factories;
+
+namespace NeptuneEvo.Database.Models
 {
     public class Repository
     {
@@ -12,6 +14,7 @@
             Phone.Start();
             Money.Start();
             Members.Start();
+            Factory.Start();
         }
     }
 }

--- a/dotnet/resources/NeptuneEvo/Database/Server/ServerStruct.generated.cs
+++ b/dotnet/resources/NeptuneEvo/Database/Server/ServerStruct.generated.cs
@@ -721,17 +721,26 @@ namespace Database
 		[Column("player"), NotNull] public int  Player { get; set; } // int(11)
 	}
 
-	[Table("mine_stocks")]
-	public partial class MineStocks
-	{
-		[Column("id"),      PrimaryKey, Identity] public int Id      { get; set; } // int(11)
-		[Column("coal"),    NotNull             ] public int Coal    { get; set; } // int(11)
-		[Column("iron"),    NotNull             ] public int Iron    { get; set; } // int(11)
-		[Column("gold"),    NotNull             ] public int Gold    { get; set; } // int(11)
-		[Column("sulfur"),  NotNull             ] public int Sulfur  { get; set; } // int(11)
-		[Column("emerald"), NotNull             ] public int Emerald { get; set; } // int(11)
-		[Column("ruby"),    NotNull             ] public int Ruby    { get; set; } // int(11)
-	}
+        [Table("mine_stocks")]
+        public partial class MineStocks
+        {
+                [Column("id"),      PrimaryKey, Identity] public int Id      { get; set; } // int(11)
+                [Column("coal"),    NotNull             ] public int Coal    { get; set; } // int(11)
+                [Column("iron"),    NotNull             ] public int Iron    { get; set; } // int(11)
+                [Column("gold"),    NotNull             ] public int Gold    { get; set; } // int(11)
+                [Column("sulfur"),  NotNull             ] public int Sulfur  { get; set; } // int(11)
+                [Column("emerald"), NotNull             ] public int Emerald { get; set; } // int(11)
+                [Column("ruby"),    NotNull             ] public int Ruby    { get; set; } // int(11)
+        }
+
+        [Table("factory_data")]
+        public partial class FactoryDatas
+        {
+                [Column("id"),        PrimaryKey,  NotNull] public int    Id        { get; set; } // int(11)
+                [Column("materials"), NotNull] public string Materials { get; set; } // text
+                [Column("products"),  NotNull] public string Products  { get; set; } // text
+                [Column("queue"),     NotNull] public string Queue     { get; set; } // text
+        }
 
 	[Table("money")]
 	public partial class Moneys
@@ -1240,15 +1249,21 @@ namespace Database
 				t.AutoId == AutoId);
 		}
 
-		public static MineStocks Find(this ITable<MineStocks> table, int Id)
-		{
-			return table.FirstOrDefault(t =>
-				t.Id == Id);
-		}
+                public static MineStocks Find(this ITable<MineStocks> table, int Id)
+                {
+                        return table.FirstOrDefault(t =>
+                                t.Id == Id);
+                }
 
-		public static Moneys Find(this ITable<Moneys> table, int Id)
-		{
-			return table.FirstOrDefault(t =>
+                public static FactoryDatas Find(this ITable<FactoryDatas> table, int Id)
+                {
+                        return table.FirstOrDefault(t =>
+                                t.Id == Id);
+                }
+
+                public static Moneys Find(this ITable<Moneys> table, int Id)
+                {
+                        return table.FirstOrDefault(t =>
 				t.Id == Id);
 		}
 

--- a/dotnet/resources/NeptuneEvo/Jobs/Miner.cs
+++ b/dotnet/resources/NeptuneEvo/Jobs/Miner.cs
@@ -57,6 +57,21 @@ namespace NeptuneEvo.Jobs
 
         public static ExtTextLabel MineStockLabel { get; set; } = null;
         public static ExtTextLabel PlantStockLabel { get; set; } = null;
+
+        public static int GetPlantOre(int index)
+        {
+            if (index < 0 || index >= PlantStockOres.Count) return 0;
+            return PlantStockOres[index];
+        }
+
+        public static bool TakePlantOre(int index, int amount)
+        {
+            if (index < 0 || index >= PlantStockOres.Count) return false;
+            if (PlantStockOres[index] < amount) return false;
+            PlantStockOres[index] -= amount;
+            SaveMineStocks(2);
+            return true;
+        }
         public static readonly Dictionary<int, int> OrePricePerUnit = new Dictionary<int, int>()
         {
             { 0, 10 },   // Уголь — 10$

--- a/dotnet/resources/NeptuneEvo/Jobs/Truckers.cs
+++ b/dotnet/resources/NeptuneEvo/Jobs/Truckers.cs
@@ -262,11 +262,20 @@ namespace NeptuneEvo.Jobs
                     }
                 }
 
-                var product = biz.Products.FirstOrDefault(p => p.Name == bizOrder.Name);
-                if (product != null) 
+                if (biz.Type == 16 && biz is NeptuneEvo.Businesses.Factories.FactoryBusiness factory)
                 {
-                    product.Ordered = false;
-                    product.Lefts += bizOrder.Amount;
+                    if (!factory.MaterialsStorage.ContainsKey(bizOrder.Name))
+                        factory.MaterialsStorage[bizOrder.Name] = 0;
+                    factory.MaterialsStorage[bizOrder.Name] += bizOrder.Amount;
+                }
+                else
+                {
+                    var product = biz.Products.FirstOrDefault(p => p.Name == bizOrder.Name);
+                    if (product != null)
+                    {
+                        product.Ordered = false;
+                        product.Lefts += bizOrder.Amount;
+                    }
                 }
                 
                 biz.Orders.Remove(bizOrder);

--- a/dotnet/resources/NeptuneEvo/Players/Phone/Property/Businesses/Repository.cs
+++ b/dotnet/resources/NeptuneEvo/Players/Phone/Property/Businesses/Repository.cs
@@ -217,6 +217,15 @@ namespace NeptuneEvo.Players.Phone.Property.Businesses
             product.Ordered = true;
             biz.Orders.Add(order);
             BusinessManager.Orders.TryAdd(order.UID, biz.ID);
+
+            if (biz.Type == 6)
+            {
+                var factory = BusinessManager.BizList.Values.FirstOrDefault(b => b.Type == 16) as NeptuneEvo.Businesses.Factories.FactoryBusiness;
+                if (factory != null)
+                {
+                    factory.StartProduction(order.Name, order.Amount, new Dictionary<string, int>(), TimeSpan.FromMinutes(5));
+                }
+            }
             
             Trigger.ClientEvent(player, "client.phone.business.cAddOrder", order.UID, order.Name, order.Amount);
             


### PR DESCRIPTION
## Summary
- implement `FactoryBusiness` with production queues and storage
- hook new factory business type into manager
- expose ore stock helpers in `Miner`
- adjust trucker delivery for factories
- allow gunshops to start factory production
- create DB model/table for factory persistence

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b5e64888832fb35e138de6533755